### PR TITLE
Feature/better commands

### DIFF
--- a/CWE/Modules/TagsModule.cs
+++ b/CWE/Modules/TagsModule.cs
@@ -101,7 +101,7 @@ namespace CWE.Modules
             await this.DataAccessLayer.CreateTag(tagName, this.Context.User.Id, tagContent);
             var created = new CWEEmbedBuilder()
                 .WithTitle("Tag created")
-                .WithDescription($"The tag has been created. You can view it by using `{this.Configuration.GetValue<string>("Prefix")}tag {tagName}`, or by using `${tagName}` inline.")
+                .WithDescription($"The tag has been created. You can view it by using `${tagName}`.")
                 .WithStyle(EmbedStyle.Success)
                 .Build();
 

--- a/CWE/Modules/TagsModule.cs
+++ b/CWE/Modules/TagsModule.cs
@@ -1,4 +1,6 @@
-﻿namespace CWE.Modules
+﻿using System.ComponentModel;
+
+namespace CWE.Modules
 {
     using System;
     using System.Linq;
@@ -14,6 +16,8 @@
     /// The tags module, used to view, create, modify and delete tags.
     /// </summary>
     [Name("Tags")]
+    [Group("tag")]
+    [Alias("t", "tags")]
     public class TagsModule : CWEModuleBase
     {
         /// <summary>
@@ -31,7 +35,7 @@
         /// The command used to get all tags.
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
-        [Command("tags")]
+        [Command]
         public async Task Tags()
         {
             var tags = await this.DataAccessLayer.GetTags();
@@ -53,7 +57,7 @@
             var list = new CWEEmbedBuilder()
                     .WithTitle($"Tags ({tags.Count()})")
                     .WithDescription(description)
-                    .WithFooter($"Use \"{this.Configuration.GetValue<string>("Prefix")}t name\" to view a tag")
+                    .WithFooter($"Use \"{this.Configuration.GetValue<string>("Prefix")}t name\" to view a tag, or use $name to view it.")
                     .WithStyle(EmbedStyle.Information)
                     .Build();
 
@@ -94,76 +98,6 @@
 
             switch (arguments[0])
             {
-                case "create":
-                    var tag = await this.DataAccessLayer.GetTag(arguments[1]);
-                    if (tag != null)
-                    {
-                        var embed = new CWEEmbedBuilder()
-                            .WithTitle("Already exists")
-                            .WithDescription("There already exists a tag with that name.")
-                            .WithStyle(EmbedStyle.Error)
-                            .Build();
-
-                        await this.Context.Channel.SendMessageAsync(embed: embed);
-                        return;
-                    }
-
-                    if (!this.Context.User.IsPromoted())
-                    {
-                        var embed = new CWEEmbedBuilder()
-                            .WithTitle("Access denied")
-                            .WithDescription("You need to be a helper, contributor or administrator in order to create tags.")
-                            .WithStyle(EmbedStyle.Error)
-                            .Build();
-
-                        await this.Context.Channel.SendMessageAsync(embed: embed);
-                        return;
-                    }
-
-                    await this.DataAccessLayer.CreateTag(arguments[1], this.Context.User.Id, string.Join(" ", arguments.Skip(2)));
-                    var created = new CWEEmbedBuilder()
-                            .WithTitle("Tag created")
-                            .WithDescription($"The tag has been created. You can view it by using `{this.Configuration.GetValue<string>("Prefix")}tag {arguments[1]}`.")
-                            .WithStyle(EmbedStyle.Success)
-                            .Build();
-
-                    await this.Context.Channel.SendMessageAsync(embed: created);
-                    break;
-                case "edit":
-                    var foundTag = await this.DataAccessLayer.GetTag(arguments[1]);
-                    if (foundTag == null)
-                    {
-                        var embed = new CWEEmbedBuilder()
-                            .WithTitle("Not found")
-                            .WithDescription("That tag could not be found.")
-                            .WithStyle(EmbedStyle.Error)
-                            .Build();
-
-                        await this.Context.Channel.SendMessageAsync(embed: embed);
-                        return;
-                    }
-
-                    if (foundTag.OwnerId != this.Context.User.Id && !socketGuildUser.GuildPermissions.Administrator)
-                    {
-                        var embed = new CWEEmbedBuilder()
-                            .WithTitle("Access denied")
-                            .WithDescription("You need to be the owner of this tag or an administrator to edit the content of this tag.")
-                            .WithStyle(EmbedStyle.Error)
-                            .Build();
-
-                        await this.Context.Channel.SendMessageAsync(embed: embed);
-                        return;
-                    }
-
-                    await this.DataAccessLayer.EditTagContent(arguments[1], string.Join(" ", arguments.Skip(2)));
-                    var edited = new CWEEmbedBuilder()
-                            .WithTitle("Tag content modified")
-                            .WithDescription($"The content of the tag was successfully modified.")
-                            .WithStyle(EmbedStyle.Success)
-                            .Build();
-
-                    await this.Context.Channel.SendMessageAsync(embed: edited);
-                    break;
                 case "transfer":
                     var tagToTransfer = await this.DataAccessLayer.GetTag(arguments[1]);
                     if (tagToTransfer == null)
@@ -211,42 +145,174 @@
 
                     await this.Context.Channel.SendMessageAsync(embed: success);
                     break;
-                case "delete":
-                    var tagToDelete = await this.DataAccessLayer.GetTag(arguments[1]);
-                    if (tagToDelete == null)
-                    {
-                        var embed = new CWEEmbedBuilder()
-                            .WithTitle("Not found")
-                            .WithDescription("That tag could not be found.")
-                            .WithStyle(EmbedStyle.Error)
-                            .Build();
-
-                        await this.Context.Channel.SendMessageAsync(embed: embed);
-                        return;
-                    }
-
-                    if (tagToDelete.OwnerId != this.Context.User.Id && !socketGuildUser.GuildPermissions.Administrator)
-                    {
-                        var embed = new CWEEmbedBuilder()
-                            .WithTitle("Access denied")
-                            .WithDescription("You need to be the owner of this tag or an administrator to delete this tag.")
-                            .WithStyle(EmbedStyle.Error)
-                            .Build();
-
-                        await this.Context.Channel.SendMessageAsync(embed: embed);
-                        return;
-                    }
-
-                    await this.DataAccessLayer.DeleteTag(arguments[1]);
-                    var deleted = new CWEEmbedBuilder()
-                            .WithTitle("Tag deleted")
-                            .WithDescription($"The tag was successfully deleted.")
-                            .WithStyle(EmbedStyle.Success)
-                            .Build();
-
-                    await this.Context.Channel.SendMessageAsync(embed: deleted);
-                    break;
             }
+        }
+
+        /// <summary>
+        /// The command used to create a tag.
+        /// </summary>
+        /// <param name="tagName">The name of the new tag.</param>
+        /// <param name="tagContent">The content of the new tag.</param>
+        /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
+        [Command("create")]
+        public async Task Create(string tagName, string tagContent)
+        {
+            var tag = await this.DataAccessLayer.GetTag(tagName);
+            if (tag != null)
+            {
+                var embed = new CWEEmbedBuilder()
+                    .WithTitle("Already exists")
+                    .WithDescription("There already exists a tag with that name.")
+                    .WithStyle(EmbedStyle.Error)
+                    .Build();
+
+                await this.Context.Channel.SendMessageAsync(embed: embed);
+                return;
+            }
+
+            if (!this.Context.User.IsPromoted())
+            {
+                var embed = new CWEEmbedBuilder()
+                    .WithTitle("Access denied")
+                    .WithDescription("You need to be a helper, contributor or administrator in order to create tags.")
+                    .WithStyle(EmbedStyle.Error)
+                    .Build();
+
+                await this.Context.Channel.SendMessageAsync(embed: embed);
+                return;
+            }
+
+            await this.DataAccessLayer.CreateTag(tagName, this.Context.User.Id, tagContent);
+            var created = new CWEEmbedBuilder()
+                .WithTitle("Tag created")
+                .WithDescription($"The tag has been created. You can view it by using `{this.Configuration.GetValue<string>("Prefix")}tag {tagName}`, or by using `${tagName}` inline.")
+                .WithStyle(EmbedStyle.Success)
+                .Build();
+
+            await this.ReplyAsync(embed: created);
+        }
+        
+        /// <summary>
+        /// The command used to edit the content of a tag.
+        /// </summary>
+        /// <param name="tagName">The name of the tag.</param>
+        /// <param name="newContent">The new content that should be applied to the tag.</param>
+        /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
+        [Command("edit")]
+        public async Task Edit(string tagName, [Remainder] string newContent)
+        {
+            var socketGuildUser = this.Context.User as SocketGuildUser;
+            var tag = await this.DataAccessLayer.GetTag(tagName);
+            if (tag == null)
+            {
+                var embed = new CWEEmbedBuilder()
+                    .WithTitle("Not found")
+                    .WithDescription("That tag could not be found.")
+                    .WithStyle(EmbedStyle.Error)
+                    .Build();
+
+                await this.Context.Channel.SendMessageAsync(embed: embed);
+                return;
+            }
+
+            if (tag.OwnerId != this.Context.User.Id && !socketGuildUser.GuildPermissions.Administrator)
+            {
+                var embed = new CWEEmbedBuilder()
+                    .WithTitle("Access denied")
+                    .WithDescription("You need to be the owner of this tag or an administrator to edit the content of this tag.")
+                    .WithStyle(EmbedStyle.Error)
+                    .Build();
+
+                await this.Context.Channel.SendMessageAsync(embed: embed);
+                return;
+            }
+
+            await this.DataAccessLayer.EditTagContent(tagName, newContent);
+            var edited = new CWEEmbedBuilder()
+                .WithTitle("Tag content modified")
+                .WithDescription($"The content of the tag was successfully modified.")
+                .WithStyle(EmbedStyle.Success)
+                .Build();
+
+            await this.ReplyAsync(embed: edited);
+        }
+
+        /// <summary>
+        /// The command used to delete a tag.
+        /// </summary>
+        /// <param name="tagName">The name of the tag to be deleted.</param>
+        [Command("delete")]
+        public async Task Delete(string tagName)
+        {
+            var socketGuildUser = this.Context.User as SocketGuildUser;
+            var tag = await this.DataAccessLayer.GetTag(tagName);
+            if (tag == null)
+            {
+                var embed = new CWEEmbedBuilder()
+                    .WithTitle("Not found")
+                    .WithDescription("That tag could not be found.")
+                    .WithStyle(EmbedStyle.Error)
+                    .Build();
+
+                await this.Context.Channel.SendMessageAsync(embed: embed);
+                return;
+            }
+
+            if (tag.OwnerId != this.Context.User.Id && !socketGuildUser.GuildPermissions.Administrator)
+            {
+                var embed = new CWEEmbedBuilder()
+                    .WithTitle("Access denied")
+                    .WithDescription("You need to be the owner of this tag or an administrator to delete this tag.")
+                    .WithStyle(EmbedStyle.Error)
+                    .Build();
+
+                await this.Context.Channel.SendMessageAsync(embed: embed);
+                return;
+            }
+
+            await this.DataAccessLayer.DeleteTag(tagName);
+            var deleted = new CWEEmbedBuilder()
+                .WithTitle("Tag deleted")
+                .WithDescription($"The tag was successfully deleted.")
+                .WithStyle(EmbedStyle.Success)
+                .Build();
+
+            await this.ReplyAsync(embed: deleted);
+        }
+
+        [Command("transfer")]
+        public async Task Transfer(string tagName, SocketGuildUser newOwner)
+        {
+            var socketGuildUser = this.Context.User as SocketGuildUser;
+            var tagToTransfer = await this.DataAccessLayer.GetTag(tagName);
+            if (tagToTransfer == null)
+            {
+                var embed = new CWEEmbedBuilder()
+                    .WithTitle("Not found")
+                    .WithDescription("That tag could not be found.")
+                    .WithStyle(EmbedStyle.Error)
+                    .Build();
+                await this.Context.Channel.SendMessageAsync(embed: embed);
+                return;
+            }
+            if (tagToTransfer.OwnerId != this.Context.User.Id && !socketGuildUser.GuildPermissions.Administrator)
+            {
+                var embed = new CWEEmbedBuilder()
+                    .WithTitle("Access denied")
+                    .WithDescription("You need to be the owner of this tag or an administrator to transfer the ownership of this tag.")
+                    .WithStyle(EmbedStyle.Error)
+                    .Build();
+                await this.Context.Channel.SendMessageAsync(embed: embed);
+                return;
+            }
+            
+            await this.DataAccessLayer.EditTagOwner(tagName, newOwner.Id);
+            var success = new CWEEmbedBuilder()
+                .WithTitle("Tag ownership transferred")
+                .WithDescription($"The ownership of the tag has been transferred to {newOwner.Mention}")
+                .WithStyle(EmbedStyle.Success)
+                .Build();
+            await this.ReplyAsync(embed: success);
         }
     }
 }

--- a/CWE/Modules/TagsModule.cs
+++ b/CWE/Modules/TagsModule.cs
@@ -57,97 +57,13 @@ namespace CWE.Modules
             var list = new CWEEmbedBuilder()
                     .WithTitle($"Tags ({tags.Count()})")
                     .WithDescription(description)
-                    .WithFooter($"Use \"{this.Configuration.GetValue<string>("Prefix")}t name\" to view a tag, or use $name to view it.")
+                    .WithFooter($"Use $tagName to view it.")
                     .WithStyle(EmbedStyle.Information)
                     .Build();
 
             await this.Context.Channel.SendMessageAsync(embed: list);
         }
-
-        /// <summary>
-        /// The command used to get, create, modify and delete a tag.
-        /// </summary>
-        /// <param name="argument">A string argument that is later converted to an array of strings.</param>
-        /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
-        [Command("tag")]
-        [Alias("t")]
-        public async Task Tag([Remainder] string argument)
-        {
-            var arguments = argument.Split(" ");
-
-            if (arguments.Count() == 1 && arguments[0] != "create" && arguments[0] != "edit" && arguments[0] != "transfer" && arguments[0] != "delete")
-            {
-                var tag = await this.DataAccessLayer.GetTag(arguments[0]);
-                if (tag == null)
-                {
-                    var embed = new CWEEmbedBuilder()
-                        .WithTitle("Not found")
-                        .WithDescription("The tag you requested could not be found.")
-                        .WithStyle(EmbedStyle.Error)
-                        .Build();
-
-                    await this.Context.Channel.SendMessageAsync(embed: embed);
-                    return;
-                }
-
-                await this.Context.Channel.SendMessageAsync(tag.Content);
-                return;
-            }
-
-            var socketGuildUser = this.Context.User as SocketGuildUser;
-
-            switch (arguments[0])
-            {
-                case "transfer":
-                    var tagToTransfer = await this.DataAccessLayer.GetTag(arguments[1]);
-                    if (tagToTransfer == null)
-                    {
-                        var embed = new CWEEmbedBuilder()
-                            .WithTitle("Not found")
-                            .WithDescription("That tag could not be found.")
-                            .WithStyle(EmbedStyle.Error)
-                            .Build();
-
-                        await this.Context.Channel.SendMessageAsync(embed: embed);
-                        return;
-                    }
-
-                    if (!MentionUtils.TryParseUser(arguments[2], out ulong userId) || this.Context.Guild.GetUser(userId) == null)
-                    {
-                        var embed = new CWEEmbedBuilder()
-                            .WithTitle("Invalid user")
-                            .WithDescription("Please provide a valid user.")
-                            .WithStyle(EmbedStyle.Error)
-                            .Build();
-
-                        await this.Context.Channel.SendMessageAsync(embed: embed);
-                        return;
-                    }
-
-                    if (tagToTransfer.OwnerId != this.Context.User.Id && !socketGuildUser.GuildPermissions.Administrator)
-                    {
-                        var embed = new CWEEmbedBuilder()
-                            .WithTitle("Access denied")
-                            .WithDescription("You need to be the owner of this tag or an administrator to transfer the ownership of this tag.")
-                            .WithStyle(EmbedStyle.Error)
-                            .Build();
-
-                        await this.Context.Channel.SendMessageAsync(embed: embed);
-                        return;
-                    }
-
-                    await this.DataAccessLayer.EditTagOwner(arguments[1], userId);
-                    var success = new CWEEmbedBuilder()
-                            .WithTitle("Tag ownership transferred")
-                            .WithDescription($"The ownership of the tag has been transferred to <@{userId}>.")
-                            .WithStyle(EmbedStyle.Success)
-                            .Build();
-
-                    await this.Context.Channel.SendMessageAsync(embed: success);
-                    break;
-            }
-        }
-
+        
         /// <summary>
         /// The command used to create a tag.
         /// </summary>


### PR DESCRIPTION
This pull request is to improve how tag commands are handled. In this pull request, I have made use of the `Group` attribute to abolish the need of having commands like `tag create` `tag delete` etc. The group attribute serves as an additional prefix.